### PR TITLE
Update `.gitignore` and retrieval demo script for model directory management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# Model weights
+mammut_vqa_model/
+cpu/
+*.zip

--- a/retrieval_demo.py
+++ b/retrieval_demo.py
@@ -29,7 +29,7 @@ import tensorflow_text  # pylint:disable=unused-import
 np.set_printoptions(precision=3)
 
 _SAVED_MODEL_PATH = flags.DEFINE_string(
-    'saved_model_path', './checkpoints/mammut_retrieval_model',
+    'saved_model_path', './checkpoints/cpu',
     'Path to the saved model.')
 
 _IMAGE_TEXT_PAIRS = [


### PR DESCRIPTION
I've made the following changes:
- Added the zip files and directories of both `mammut_retrieval_model` and `mammut_vqa_model` to `.gitignore` to prevent future contributors from accidentally pushing these model weights.
- Updated the model checkpoint in `retrieval_demo.py` from `mammut_retrieval_model` to `cpu` (the directory name that appeared after unzipping it).